### PR TITLE
Fix sa_family_t workaround for recent API levels

### DIFF
--- a/packages/vulkan-wrapper-android/build.sh
+++ b/packages/vulkan-wrapper-android/build.sh
@@ -82,19 +82,19 @@ termux_step_pre_configure() {
 
 	local target_file="$TERMUX_PKG_SRCDIR/src/vulkan/wsi/wsi_common_x11.c"
 
-	if [ -f "$target_file" ] && grep -q '#include <sys/socket.h>' "$target_file"; then
-		awk '
-			/#include <sys\/socket.h>/ {
-				print "#if defined(__ANDROID__) && __ANDROID_API__ < 24"
-				print "#ifndef _SA_FAMILY_T_DEFINED"
-				print "#define _SA_FAMILY_T_DEFINED"
-				print "typedef unsigned short sa_family_t;"
-				print "#endif"
-				print "#endif"
-			}
-			{ print }
-		' "$target_file" > "$target_file.new" && mv "$target_file.new" "$target_file"
-	fi
+       if [ -f "$target_file" ] && [ "$TERMUX_PKG_API_LEVEL" -lt 24 ] && grep -q '#include <sys/socket.h>' "$target_file"; then
+               awk '
+                       /#include <sys\/socket.h>/ {
+                               print "#if defined(__ANDROID__) && __ANDROID_API__ < 24"
+                               print "#ifndef _SA_FAMILY_T_DEFINED"
+                               print "#define _SA_FAMILY_T_DEFINED"
+                               print "typedef unsigned short sa_family_t;"
+                               print "#endif"
+                               print "#endif"
+                       }
+                       { print }
+               ' "$target_file" > "$target_file.new" && mv "$target_file.new" "$target_file"
+       fi
 	if [ -f "$target_file" ] && ! grep -q '__TERMUX__' "$target_file"; then
 		sed -i '/static const VkPresentModeKHR present_modes\[\] = {/,/VK_PRESENT_MODE_MAILBOX_KHR,/s/^\(\s*\)VK_PRESENT_MODE_IMMEDIATE_KHR,/\
 \1#ifndef __TERMUX__\


### PR DESCRIPTION
## Summary
- adjust build script to only apply sa_family_t workaround when building for API levels below 24

## Testing
- `bash scripts/lint-packages.sh packages/vulkan-wrapper-android/build.sh` *(fails: `xxd` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68408c197bc4832fac0c132b149b4db2